### PR TITLE
Feature/when user reply topic is still unread

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,5 +1,5 @@
-import { cnsl, getFollowedForums, getLastSnapshot, backupUpdates, getUpdates, setGlobalConfiguration, getGlobalConfiguration, forumSnapshot } from "./functions";
-import { ForumsFollowed, Topic, Snapshot, Update, GlobalConfiguration, DefaultGlobalConfiguration, ForumInfos } from "./classes";
+import { cnsl, getFollowedForums, getLastSnapshot, backupUpdates, setGlobalConfiguration, getGlobalConfiguration, forumSnapshot } from "./functions";
+import { ForumsFollowed, Topic, Snapshot, Update, GlobalConfiguration, ForumInfos } from "./classes";
 import { defaultConfig } from "./objects";
 
 // TODO => Changer la couleur du badge si une nouvelle mise à jour, après une mise à jour. Et remettre la couleur par défaut au clic.

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -130,7 +130,7 @@ export class Topic {
         const urlMatchs = urlFull.match(idRegex)[0].split('-');
 
         let id = urlMatchs[2];
-        let url = urlFull; // TODO => Récupérer l'URL du topic dans le futur
+        let url = urlFull;
         let subject = element.children[0].innerText;
         let author = element.children[1].innerText;
         let count = element.children[2].innerText;
@@ -223,8 +223,10 @@ export interface SnapshotTopics {
 
 export interface ForumInfos {
     id?: string;
+    topicId?: string;
     isTopForum: boolean;
     snapshot?: Snapshot;
+    url: string;
 }
 
 export interface TopicsAndElements {

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,4 +1,4 @@
-import { cnsl, getLastSnapshot, getFollowedForums, updateFollowStatus, getForumInformations, getUpdates, backupUpdates, updateBadgeCount } from "./functions";
+import { cnsl, getLastSnapshot, getFollowedForums, updateFollowStatus, getForumInformations, getUpdates, backupUpdates, updateBadgeCount, forumSnapshot } from "./functions";
 import { ForumInfos, TopicsAndElements, Snapshot, Topic, SnapshotChanges, Forum, ChromeTab, UpdateBackup } from "./classes";
 
 cnsl('Content script loaded at', Date.now());
@@ -112,24 +112,7 @@ function extractTopicsFromHTML(): TopicsAndElements {
     return { topics: topics, elements: topicsElements };
 }
 
-/**
- * Permet de sauvegarder les topics d'un forum
- * @param {string} forumId - L'id du forum. Fourni dans l'URL
- * @param {Topic[]} currentTopics - Liste des topics en objet custom
- */
-function forumSnapshot(forumId: string, topics: Topic[]): void {
-    // Create a Snapshot
-    const snapshot: Snapshot = {
-        [forumId]: {
-            createdTime: Date.now(),
-            topics: topics
-        }
-    };
-    // Save it
-    chrome.storage.local.set(snapshot, () => {
-        cnsl('Data saved', snapshot);
-    })
-}
+
 
 /**
  * Update visuellement les topics qui ont été mis à jour par rapport à la dernière visite

--- a/src/contenttopicconfig.ts
+++ b/src/contenttopicconfig.ts
@@ -68,7 +68,7 @@ async function applyConfiguration(config: TopicConfig, diffs: ConfigDiffs[]) {
 
 /**
  * Si l'utilisateur répond à un topic d'un forum,
- * le compte est mis à jour directement pour qu'il n'y est pas de faux-positifs lors de la recherche de mise à jour.
+ * le compte est mis à jour directement pour qu'il n'y ait pas de faux-positifs lors de la recherche de mise à jour.
  * @param forumInfos - Informations basiques du forum courant
  */
 function listenReplyButton(forumInfos: ForumInfos): void {

--- a/src/contenttopicconfig.ts
+++ b/src/contenttopicconfig.ts
@@ -2,11 +2,11 @@
  * Applique la configuration de l'utilisateur à la partie topic / message
  */
 
-import { cnsl, getForumInformations, getGlobalConfiguration } from "./functions";
+import { cnsl, getForumInformations, getGlobalConfiguration, getLastSnapshot, forumSnapshot } from "./functions";
 import { defaultConfig } from "./objects";
-import { TopicConfig, GlobalConfiguration } from "./classes";
+import { TopicConfig, GlobalConfiguration, Snapshot, ForumInfos, Topic } from "./classes";
 
- // Script qui se lance à tout les lancements de page / onglet / tab.
+// Script qui se lance à tout les lancements de page / onglet / tab.
 chrome.runtime.sendMessage({ contentScripts: "topic-config" });
 
 chrome.runtime.onMessage.addListener(async function (request, sender, sendResponse) {
@@ -16,7 +16,9 @@ chrome.runtime.onMessage.addListener(async function (request, sender, sendRespon
             cnsl('=> Topic détecté, application de la configuration...');
             const config = await getGlobalConfiguration();
             const diffs = await findTopicConfigDiffs(config);
-            
+
+            listenReplyButton(forum);
+
             if (diffs.length > 0) {
                 applyConfiguration(config.globalConfig.topic, diffs);
             } else {
@@ -35,12 +37,12 @@ async function findTopicConfigDiffs(config: GlobalConfiguration): Promise<Config
     return new Promise(async (resolve, reject) => {
         const topicConfig = config.globalConfig.topic;
         const defaultTopicConfig = defaultConfig.globalConfig.topic;
-    
+
         const diffs: ConfigDiffs[] = [];
         if (topicConfig.previsu !== defaultTopicConfig.previsu) {
             diffs.push(ConfigDiffs.MESSAGE_PREV);
         }
-    
+
         resolve(diffs);
     });
 }
@@ -48,15 +50,32 @@ async function findTopicConfigDiffs(config: GlobalConfiguration): Promise<Config
 async function applyConfiguration(config: TopicConfig, diffs: ConfigDiffs[]) {
 
     for (let diff of diffs) {
-        switch(diff) {
+        switch (diff) {
             case ConfigDiffs.MESSAGE_PREV:
                 const buttonPrev = document.getElementsByClassName('btn-on-off active')[0];
                 if (buttonPrev && !config.previsu) {
                     (buttonPrev as HTMLButtonElement).click();
                 }
-            break;
+                break;
             case ConfigDiffs.HEADER_SIZE:
-            break;
+                break;
         }
     }
+}
+
+/**
+ * Si l'utilisateur répond à un topic d'un forum,
+ * le compte est mis à jour directement pour qu'il n'y est pas de faux-positifs lors de la recherche de mise à jour.
+ * @param forumInfos - Informations basiques du forum courant
+ */
+function listenReplyButton(forumInfos: ForumInfos): void {
+    const textArea = document.getElementById('message_topic') as HTMLTextAreaElement;
+    const replyButton = document.getElementsByClassName('btn btn-poster-msg datalayer-push js-post-message')[0];
+
+    replyButton.addEventListener('click', (event) => {
+        if (textArea.value) {
+            chrome.runtime.sendMessage({ userReplyTo: forumInfos });
+        }
+    })
+
 }

--- a/src/contenttopicconfig.ts
+++ b/src/contenttopicconfig.ts
@@ -2,9 +2,12 @@
  * Applique la configuration de l'utilisateur à la partie topic / message
  */
 
-import { cnsl, getForumInformations, getGlobalConfiguration, getLastSnapshot, forumSnapshot } from "./functions";
+import { cnsl, getForumInformations, getGlobalConfiguration } from "./functions";
 import { defaultConfig } from "./objects";
-import { TopicConfig, GlobalConfiguration, Snapshot, ForumInfos, Topic } from "./classes";
+import { TopicConfig, GlobalConfiguration, ForumInfos } from "./classes";
+
+// Disable call twice or more
+let alreadyPost = false;
 
 // Script qui se lance à tout les lancements de page / onglet / tab.
 chrome.runtime.sendMessage({ contentScripts: "topic-config" });
@@ -73,7 +76,8 @@ function listenReplyButton(forumInfos: ForumInfos): void {
     const replyButton = document.getElementsByClassName('btn btn-poster-msg datalayer-push js-post-message')[0];
 
     replyButton.addEventListener('click', (event) => {
-        if (textArea.value) {
+        if (textArea.value && !alreadyPost) {
+            alreadyPost = true;
             chrome.runtime.sendMessage({ userReplyTo: forumInfos });
         }
     })

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,4 +1,4 @@
-import { ForumsFollowed, Snapshot, Update, UpdateBackup, GlobalConfiguration, ForumInfos, Topic } from "./classes";
+import { ForumsFollowed, Snapshot, UpdateBackup, GlobalConfiguration, ForumInfos, Topic } from "./classes";
 
 const debug = true; // TODO => export into global configuration
 


### PR DESCRIPTION
Lorsqu'un utilisateur répondait à un topic, le topic restait toujours en non lu, car il prenait en compte la réponse comme un nouveau message d'un autre utilisateur.
Maintenant, cela est pris en compte, et le comportement devient plus cohérent. Exemple, en revenant sur la liste des topics, il sera en mode "lu".