### PR TITLE
check background notifier status

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -15,7 +15,7 @@ cnsl('Background script loaded at', Date.now());
  */
 
 chrome.runtime.onInstalled.addListener((details) => {
-    chrome.alarms.create('backgroundNotifications', { periodInMinutes: 2 });
+    createBackgroundJobNotifier();
     updateBadge("0");
     cnsl('Détails à l\'installation', details);
     setDefaultGlobalConfiguration();
@@ -62,7 +62,31 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
             }
         });
     }
+
+    if (request.isBackgroundJobRunning) {
+        chrome.alarms.getAll((alarms) => {
+            cnsl('Alarmes courantes', alarms);
+            if (alarms.length === 0) {
+                sendResponse('No alarm set...');
+                createBackgroundJobNotifier();
+            } else {
+                // Search Background Notifier alarm
+                const alarm = alarms.find(a => a.name === 'backgroundNotifications');
+                if (!alarm) {
+                    cnsl('Background job notifier créer');
+                    createBackgroundJobNotifier();
+                }
+            }
+        })
+    }
 });
+
+/**
+ * Création d'un job pour vérifier les mises à jour des forums suivis.
+ */
+function createBackgroundJobNotifier(): void {
+    chrome.alarms.create('backgroundNotifications', { periodInMinutes: 2 });
+}
 
 /**
  * Initialise une configuration par défaut des options.

--- a/src/content.ts
+++ b/src/content.ts
@@ -16,11 +16,10 @@ chrome.runtime.onMessage.addListener(async function (request, sender, sendRespon
             init();
             addFollowButton();
             checkUpdateBackup();
+            checkBackgroundNotifierStatus();
         }
     }
 });
-
-// TODO => Faire une méthode de vérification aléatoire pour savoir si le background job tourne toujours
 
 /**
  * Initialise les méthodes pour la page actuelle.
@@ -209,6 +208,15 @@ function checkUpdateBackup(): void {
                 updateBadgeCount(updateBackup.updates.length.toString());
             }
         }
+    });
+}
+
+/**
+ * Au chargement d'une page du forum, on vérifie si le job de synchronisation fonctionne toujours.
+ */
+function checkBackgroundNotifierStatus(): void {
+    chrome.runtime.sendMessage({ isBackgroundJobRunning: true }, (responseCallback) => {
+        cnsl(responseCallback);
     });
 }
 


### PR DESCRIPTION
Méthode de vérification du background notifier. Si celui-ci est arrêté par le système Chrome, il sera recréé automatiquement.